### PR TITLE
Optional Newlines

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,5 +1,10 @@
+# Basic
 add_executable(basic basic/basic.c)
 target_link_libraries(basic clog)
 
+add_executable(newline basic/newline.c)
+target_link_libraries(newline clog)
+
+# Extra
 add_executable(assert extra/assert.c)
 target_link_libraries(assert clog)

--- a/examples/basic/newline.c
+++ b/examples/basic/newline.c
@@ -1,5 +1,5 @@
 /*
- * CLog Basic Example
+ * CLog Manual Newline Example
  *
  * This file is released into the public domain under CC0:
  *   https://creativecommons.org/publicdomain/zero/1.0/

--- a/examples/basic/newline.c
+++ b/examples/basic/newline.c
@@ -10,9 +10,9 @@
 int main() {
     /* Initialize CLog. */
     clog_set_log_level(CLOG_LEVEL_INFO);
-    clog_set_append_newline(false);
+    clog_set_append_newline(0); /* False */
 
-    /* Some example logs: */
+    /* An example log: */
     clog_log(CLOG_LEVEL_INFO, "Newline added manually!\n");
 
     return 0;

--- a/examples/basic/newline.c
+++ b/examples/basic/newline.c
@@ -1,0 +1,19 @@
+/*
+ * CLog Basic Example
+ *
+ * This file is released into the public domain under CC0:
+ *   https://creativecommons.org/publicdomain/zero/1.0/
+ */
+
+#include "clog/clog.h"
+
+int main() {
+    /* Initialize CLog. */
+    clog_set_log_level(CLOG_LEVEL_INFO);
+    clog_set_append_newline(false);
+
+    /* Some example logs: */
+    clog_log(CLOG_LEVEL_INFO, "Newline added manually!\n");
+
+    return 0;
+}

--- a/include/clog/clog.h
+++ b/include/clog/clog.h
@@ -48,7 +48,7 @@ extern "C" {
  */
 void clog_set_log_level(clog_log_level_e level);
 /**
- * @brief Sets whether a \n newline should automatically be appended to all logs. Defaults to true (1). Uses an int instead of a bool for c89 compatibility
+ * @brief Sets whether a \n newline should automatically be appended to all logs. Defaults to true (1). Uses an int instead of a bool for C89 compatibility
  *
  * @param append Should we append \n? 0 = No, 1 = Yes
  */

--- a/include/clog/clog.h
+++ b/include/clog/clog.h
@@ -25,6 +25,7 @@
 #define CLOG_H
 
 #include <stdarg.h>
+#include <stdbool.h>
 
 /**
  * @brief Log levels supported by CLog.
@@ -48,6 +49,12 @@ extern "C" {
  */
 void clog_set_log_level(clog_log_level_e level);
 /**
+ * @brief Sets whether a \n newline should automatically be appended to all logs. Defaults to true
+ *
+ * @param append Should we append \n?
+ */
+void clog_set_append_newline(bool append);
+/**
  * @brief Sets the current log file. Messages will be logged here as well if it is not null.
  * 
  * @param filename New log filename, `NULL` is accepted and means no log file.
@@ -58,7 +65,7 @@ void clog_set_log_file(const char* filename);
  * @brief Log, using varargs.
  * 
  * @param level Log level to use.
- * @param fmt `printf`-style format string to log. `\\n` is appended automatically.
+ * @param fmt `printf`-style format string to log. `\\n` is appended depending on clog_set_append_newline().
  * @param ... Arguments to the format string.
  */
 void clog_log(clog_log_level_e level, const char* fmt, ...)

--- a/include/clog/clog.h
+++ b/include/clog/clog.h
@@ -25,7 +25,6 @@
 #define CLOG_H
 
 #include <stdarg.h>
-#include <stdbool.h>
 
 /**
  * @brief Log levels supported by CLog.
@@ -49,11 +48,11 @@ extern "C" {
  */
 void clog_set_log_level(clog_log_level_e level);
 /**
- * @brief Sets whether a \n newline should automatically be appended to all logs. Defaults to true
+ * @brief Sets whether a \n newline should automatically be appended to all logs. Defaults to true (1). Uses an int instead of a bool for c89 compatibility
  *
- * @param append Should we append \n?
+ * @param append Should we append \n? 0 = No, 1 = Yes
  */
-void clog_set_append_newline(bool append);
+void clog_set_append_newline(int append);
 /**
  * @brief Sets the current log file. Messages will be logged here as well if it is not null.
  * 

--- a/src/clog.c
+++ b/src/clog.c
@@ -36,7 +36,7 @@
 #define cstrlen(str) (sizeof(str) / sizeof(str[0]))
 
 static clog_log_level_e g_log_level = CLOG_LEVEL_DEBUG;
-static bool g_append_newline = true;
+static int g_append_newline = true;
 static FILE* g_log_file = NULL;
 static int g_has_registered_atexit = 0;
 
@@ -134,7 +134,6 @@ void clog_logv(clog_log_level_e level, const char* fmt, va_list args) {
     } else {
         sprintf(ansifmt, "\x1b[0;37m[%s%s\x1b[0;37m] [%s] \x1b[0m%s", levelansi, levelstr, timestamp, fmt);
         sprintf(cleanfmt, "[%s] [%s] %s", levelstr, timestamp, fmt);
-
     }
 
     if (level == CLOG_LEVEL_ERROR) {

--- a/src/clog.c
+++ b/src/clog.c
@@ -24,6 +24,7 @@
 #include "clog/clog.h"
 
 #include <stdarg.h>
+#include <stdbool.h>
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
@@ -35,11 +36,16 @@
 #define cstrlen(str) (sizeof(str) / sizeof(str[0]))
 
 static clog_log_level_e g_log_level = CLOG_LEVEL_DEBUG;
+static bool g_append_newline = true;
 static FILE* g_log_file = NULL;
 static int g_has_registered_atexit = 0;
 
 void clog_set_log_level(clog_log_level_e level) {
     g_log_level = level;
+}
+
+void clog_set_append_newline(bool append) {
+    g_append_newline = append;
 }
 
 static void clog_close_log_file(void) {
@@ -122,8 +128,14 @@ void clog_logv(clog_log_level_e level, const char* fmt, va_list args) {
             break;
     }
 
-    sprintf(ansifmt, "\x1b[0;37m[%s%s\x1b[0;37m] [%s] \x1b[0m%s\n", levelansi, levelstr, timestamp, fmt);
-    sprintf(cleanfmt, "[%s] [%s] %s\n", levelstr, timestamp, fmt);
+    if (g_append_newline) {
+        sprintf(ansifmt, "\x1b[0;37m[%s%s\x1b[0;37m] [%s] \x1b[0m%s\n", levelansi, levelstr, timestamp, fmt);
+        sprintf(cleanfmt, "[%s] [%s] %s\n", levelstr, timestamp, fmt);
+    } else {
+        sprintf(ansifmt, "\x1b[0;37m[%s%s\x1b[0;37m] [%s] \x1b[0m%s", levelansi, levelstr, timestamp, fmt);
+        sprintf(cleanfmt, "[%s] [%s] %s", levelstr, timestamp, fmt);
+
+    }
 
     if (level == CLOG_LEVEL_ERROR) {
         vfprintf(stderr, ansifmt, args);

--- a/src/clog.c
+++ b/src/clog.c
@@ -44,7 +44,7 @@ void clog_set_log_level(clog_log_level_e level) {
     g_log_level = level;
 }
 
-void clog_set_append_newline(bool append) {
+void clog_set_append_newline(int append) {
     g_append_newline = append;
 }
 

--- a/src/clog.c
+++ b/src/clog.c
@@ -24,7 +24,6 @@
 #include "clog/clog.h"
 
 #include <stdarg.h>
-#include <stdbool.h>
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
@@ -36,7 +35,7 @@
 #define cstrlen(str) (sizeof(str) / sizeof(str[0]))
 
 static clog_log_level_e g_log_level = CLOG_LEVEL_DEBUG;
-static int g_append_newline = true;
+static int g_append_newline = 1;
 static FILE* g_log_file = NULL;
 static int g_has_registered_atexit = 0;
 


### PR DESCRIPTION
This PR adds a global switch that lets you turn the newline that was previously automatically added on and off. By default the newline is on for compatibility's sake.